### PR TITLE
Planet API URL updated and determine when to stop seeking next url updated

### DIFF
--- a/psites.py
+++ b/psites.py
@@ -57,8 +57,8 @@ class aoi:
                                        api_cloud_cover_min= min_cloud, 
                                        api_cloud_cover_max=max_cloud )
         self.allowed = allowed
-        self.search_results = None
-        self.permission_tracker = None
+        self.search_results = {}
+        self.permission_tracker = []
         self.quick_result = None
         
         
@@ -138,10 +138,9 @@ class aoi:
         self.quick_result = []
         self.id_list = []
         self.order_chunks = None
+        self.search_results = {}
+        self.permission_tracker = []
         
-        # Create a dict to store how many items contain the desired assetts
-        permission_tracker = []
-        year_tracker = {}
           
         coords = self.aoi_feature["coordinates"]      # Feature coordinates
         api_filter = self.api_filter    # Filter to use for the search
@@ -168,79 +167,81 @@ class aoi:
         if(res.status_code != 200):
             self.__write_log__("Quick search  failed with code {}".format(res.status_code))
             self.__write_log__(json.dumps(res.json(), indent=2))
-        else:
-            
-            geojson = res.json()    # retrieve API results
-            self.quick_result.extend(geojson["features"])      # Save API results to aoi object
-            
-            
-            # Check if 0 results were returned, if yes, continue to the next feature
-            if(len(geojson["features"]) == 0):
-                self.__write_log__("0 IDs returned in quick search.")
-            
-            # The API return may contain multiple pages of results.
-            # Retrieve each page via "_next" until the feature count is 0.
-            page = 1
+            return
+        
+        response = res.json()    # retrieve API results
+        self.quick_result.extend(response["features"])      # Save API results to aoi object
+        
+        
+        # Check if 0 results were returned, if yes, continue to the next feature
+        if(len(response["features"]) == 0):
+            self.__write_log__("0 IDs returned in quick search.")
+            return
+        
+     # The API return may contain multiple pages of results.
+        # Retrieve each page via "_next" until the feature count is 0.
+        page = 1
 
-                # Save ID for item in a list
+        print("\rProcessing page {}".format(page), end="")
+        # Extract the file IDs to be downloaded and append them to id_list
+        self.extract_search_results( response)
+
+        # Get the next page.  Sleep for 5 seconds so we are not hammering the server. 
+        next_url = response["_links"]["_next"]
+        
+        while(next_url != None):
+            page = page + 1
+            time.sleep(0.1)
+            res = session.get(next_url)
             
+            print("\rProcessing page {}".format(page), end="")
+
+            # Check if API call is a success
+            if(res.status_code != 200):
+                self.__write_log__("Next page retrieval failed with code {}".format(res.status_code))
+                self.__write_log__(json.dumps(res.json(), indent=2))
+                self.__write_log__("Failed to retrieve entire list of results.  Check the status code to determine if its a server issue or user issue.")
+                return
             
-            while(len(geojson["features"]) > 0):
-                print("\rProcessing page {}".format(page), end="")
-                # Extract the file IDs to be downloaded and append them to id_list
-                for feature in geojson["features"]:
-                    self.id_list.append(feature["id"])
+            # Append the results to the json file already created.
+            response = res.json()
+            
+            self.quick_result.extend(response["features"])
+
+            next_url = response["_links"]["_next"]
+
+        self.extract_search_results( response) 
+        
+        print("\n")
+        self.api_filter = api_filter
+            
+
+    def extract_search_results(self, response):
+        for feature in response["features"]:
+            self.id_list.append(feature["id"])
                     
-                    aq_year = str(dt.strptime(feature["properties"]["acquired"], date_format).year)
-                    item_type = feature["properties"]["item_type"]
+            aq_year = str(dt.strptime(feature["properties"]["acquired"], date_format).year)
+            item_type = feature["properties"]["item_type"]
                     
-                    if aq_year not in year_tracker.keys():
-                        year_tracker[aq_year] = {item_type : {"assets_tracker": {}, "item_count": 1 }}
-                    elif (item_type not in year_tracker[aq_year].keys()):
-                        year_tracker[aq_year][item_type] = {"assets_tracker": {}, "item_count": 1 }
-                    else:
-                        year_tracker[aq_year][item_type]["item_count"] = year_tracker[aq_year][item_type]["item_count"] + 1
+            if aq_year not in self.search_results.keys():
+                self.search_results[aq_year] = {item_type : {"assets_tracker": {}, "item_count": 1 }}
+            elif (item_type not in self.search_results[aq_year].keys()):
+                self.search_results[aq_year][item_type] = {"assets_tracker": {}, "item_count": 1 }
+            else:
+                self.search_results[aq_year][item_type]["item_count"] = self.search_results[aq_year][item_type]["item_count"] + 1
                         
                     
 
-                    for asset in feature["assets"]:
-                        if asset in year_tracker[aq_year][item_type]["assets_tracker"].keys():
-                            year_tracker[aq_year][item_type]["assets_tracker"][asset]  = year_tracker[aq_year][item_type]["assets_tracker"][asset] + 1
-                        else:
-                            year_tracker[aq_year][item_type]["assets_tracker"][asset]  = 1
+            for asset in feature["assets"]:
+                if asset in self.search_results[aq_year][item_type]["assets_tracker"].keys():
+                    self.search_results[aq_year][item_type]["assets_tracker"][asset]  = self.search_results[aq_year][item_type]["assets_tracker"][asset] + 1
+                else:
+                    self.search_results[aq_year][item_type]["assets_tracker"][asset]  = 1
                             
-                    for permission in feature["_permissions"]:
-                        parsed_perm = permission.split(sep=".")[1].split(sep=":")[0]
-                        if parsed_perm not in permission_tracker:
-                            permission_tracker.append(parsed_perm)
-                            
-                 
-                page = page + 1
-                
-                # Get the next page.  Sleep for 5 seconds so we are not hammering the server. 
-                next_url = geojson["_links"]["_next"]
-                
-                time.sleep(0.1)
-                    
-                res = session.get(next_url)
-                
-                # Check if API call is a success
-                if(res.status_code != 200):
-                    self.__write_log__("Next page retrieval failed with code {}".format(res.status_code))
-                    self.__write_log__(json.dumps(res.json(), indent=2))
-                    self.__write_log__("Failed to retrieve entire list of results.  Check the status code to determine if its a server issue or user issue.")
-                
-                # Append the results to the json file already created.
-                geojson = res.json()
-                
-                self.quick_result.extend(geojson["features"]) 
-            
-            print("\n")
-            self.api_filter = api_filter
-            
-                  
-        self.search_results = year_tracker
-        self.permission_tracker = permission_tracker
+            for permission in feature["_permissions"]:
+                parsed_perm = permission.split(sep=".")[1].split(sep=":")[0]
+                if parsed_perm not in self.permission_tracker:
+                    self.permission_tracker.append(parsed_perm)
     
     def print_search(self):   
         

--- a/psites.py
+++ b/psites.py
@@ -128,7 +128,7 @@ class aoi:
         print("Asking Planet for results.")
         
         # Get the API Key
-        PLANET_API_KEY = os.environ["PL_API_KEY"] 
+        PLANET_API_KEY = get_api_key()
         
         # Setup the session to communicate with Planet's API
         session = requests.Session()
@@ -280,7 +280,7 @@ class aoi:
         
         print("\nITEM TYPE DEFINITIONS")   
         
-        PLANET_API_KEY = os.environ["PL_API_KEY"] 
+        PLANET_API_KEY = get_api_key()
         with requests.Session() as session:
             session.auth = (PLANET_API_KEY, "")
             response = session.get("https://api.planet.com/data/v1/item-types")
@@ -292,7 +292,7 @@ class aoi:
             
         print("\nASSET NAME DEFINITIONS")   
         
-        PLANET_API_KEY = os.environ["PL_API_KEY"] 
+        PLANET_API_KEY = get_api_key()
         with requests.Session() as session:
             session.auth = (PLANET_API_KEY, "")
             response = session.get("https://api.planet.com/data/v1/asset-types")
@@ -367,7 +367,7 @@ class aoi_order(aoi):
         
         
         headers = {'content-type': 'application/json'}
-        PLANET_API_KEY = os.getenv('PL_API_KEY')
+        PLANET_API_KEY = get_api_key()
         
         
         with requests.Session() as session:
@@ -461,17 +461,7 @@ def check_base_server(subs_url=subs_url):
     
     print("Authenticating with Planet Server....", end="")
     # Extract the API key from the environment variable
-    PLANET_API_KEY = os.getenv('PL_API_KEY')
-    
-    # Check if the key exists, if not request for it
-    if(isinstance(PLANET_API_KEY, str) == False or len(PLANET_API_KEY) == 0):
-        print("Please provide API key below, or define it by setting" + \
-                " the PL_API_KEY environment variable before running the code.")
-                    
-        PLANET_API_KEY = input('Planet API Key ( or q to quit) : ')
-        
-        if(PLANET_API_KEY.lower() == 'q'):
-            sys.exit()
+    PLANET_API_KEY = get_api_key()
     
     # Loop until authentication is successful or 'q' is hit
     while True:
@@ -502,6 +492,20 @@ def check_base_server(subs_url=subs_url):
     
     # Set environment variable PL_API_KEY with the key
     os.environ["PL_API_KEY"] = PLANET_API_KEY
+
+def get_api_key():
+    PLANET_API_KEY = os.getenv('PL_API_KEY')
+    
+    # Check if the key exists, if not request for it
+    if(isinstance(PLANET_API_KEY, str) == False or len(PLANET_API_KEY) == 0):
+        print("Please provide API key below, or define it by setting" + \
+                " the PL_API_KEY environment variable before running the code.")
+                    
+        PLANET_API_KEY = input('Planet API Key ( or q to quit) : ')
+        
+        if(PLANET_API_KEY.lower() == 'q'):
+            sys.exit()
+    return PLANET_API_KEY
     
     
     
@@ -621,7 +625,7 @@ def get_gjson_filelist(geojson_path):
 
 def get_order_list(order_url=orders_url):
     
-    PLANET_API_KEY = os.getenv('PL_API_KEY')
+    PLANET_API_KEY = get_api_key()
     
     orders_list = []
     with requests.Session() as session:

--- a/psites.py
+++ b/psites.py
@@ -130,9 +130,6 @@ class aoi:
         # Get the API Key
         PLANET_API_KEY = get_api_key()
         
-        # Setup the session to communicate with Planet's API
-        session = requests.Session()
-        session.auth = (PLANET_API_KEY, "")
         
         # Reset quick_result object
         self.quick_result = []
@@ -161,7 +158,10 @@ class aoi:
         request = { "filter" : api_filter, "item_types" : item_types }
     
         # Send the POST request to the API stats endpoint
-        res = session.post(quick_url, json=request)
+        # Setup the session to communicate with Planet's API
+        with requests.Session() as session:
+            session.auth = (PLANET_API_KEY, "")
+            res = session.post(quick_url, json=request)
         
         # Check the status code
         if(res.status_code != 200):
@@ -192,7 +192,9 @@ class aoi:
         while(next_url != None):
             page = page + 1
             time.sleep(0.1)
-            res = session.get(next_url)
+            with requests.Session() as session:
+                session.auth = (PLANET_API_KEY, "")
+                res = session.get(next_url)
             
             print("\rProcessing page {}".format(page), end="")
 
@@ -467,9 +469,9 @@ def check_base_server(subs_url=subs_url):
     while True:
         
         # Setup test session
-        session = requests.Session()
-        session.auth = (PLANET_API_KEY, "")
-        res = session.get(subs_url)
+        with requests.Session() as session:
+            session.auth = (PLANET_API_KEY, "")
+            res = session.get(subs_url)
         
         # Check status code
         if(res.status_code == 401):
@@ -631,8 +633,6 @@ def get_order_list(order_url=orders_url):
     with requests.Session() as session:
         # Authenticate
         session.auth = (PLANET_API_KEY, "")
-        
-        
         response = session.get(order_url)
         
         if(response.status_code == 200):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
The following updates were due to Planet Labs API changing:
- New API url
- For searches, the next_url object now return `None` when we reached the last page of results.

Refactored the following items:
- Extracted a method that parses the results of a search.
- Create a `get_api_key` function
- Updated all instances of request session creation to use context manager `with`